### PR TITLE
Update card-itacns.c

### DIFF
--- a/src/libopensc/card-itacns.c
+++ b/src/libopensc/card-itacns.c
@@ -41,6 +41,7 @@
 
 #ifdef ENABLE_ITACNS_SM
 #include <openssl/evp.h>
+#include <openssl/rand.h>
 #endif
 
 #define ITACNS_MAX_PAYLOAD 0xff


### PR DESCRIPTION
include openssl/rand.h since RAND_bytes is used in the implementation
